### PR TITLE
chore: update Code of Conduct contact to GitHub profile

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at bel136@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by contacting [@Specter099](https://github.com/Specter099) via GitHub. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
## Summary

Replaces the personal email address in the Code of Conduct enforcement section with the [@Specter099](https://github.com/Specter099) GitHub profile link.

## Change

```diff
- enforcement at bel136@gmail.com
+ by contacting @Specter099 via GitHub
```