### PR TITLE
fix: upgrade pip and ignore unfixed CVE in pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,7 @@ jobs:
         run: coverage report
 
       - name: Audit dependencies
-        run: pip-audit
+        run: |
+          pip install --upgrade pip
+          pip install pip-audit
+          pip-audit --ignore-vuln CVE-2026-3219


### PR DESCRIPTION
## Summary

- pip 26.0.1 (pre-installed on GitHub runners) has two CVEs flagged by pip-audit:
  - **CVE-2026-6357**: fixed in pip 26.1 — resolved by adding `pip install --upgrade pip` before running pip-audit
  - **CVE-2026-3219**: no fix available yet — ignored via `--ignore-vuln CVE-2026-3219` until a patch is released
- Also explicitly installs pip-audit (was previously relying on it being in dev deps)

## Test plan

- [ ] CI pipeline passes on this PR (pip-audit no longer exits non-zero)
- [ ] Verify `pip install --upgrade pip` pulls pip >= 26.1
- [ ] Verify `--ignore-vuln CVE-2026-3219` suppresses the unfixed CVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)